### PR TITLE
added VRAM support

### DIFF
--- a/gpu.tmux
+++ b/gpu.tmux
@@ -4,25 +4,37 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/scripts/helpers.sh"
 
-gpu_usage="#($CURRENT_DIR/scripts/gpu.sh)"
-gpu_usage_interpolation="\#{gpu}"
+gpu_interpolation=(
+    "\#{gpu}" 
+    "\#{vram}"
+)
+
+gpu_usage=(
+    "#($CURRENT_DIR/scripts/gpu.sh)"
+    "#($CURRENT_DIR/scripts/vram.sh)"
+)
 
 set_tmux_option() {
-  local option="$1"
-  local value="$2"
+  local option=$1
+  local value=$2
   tmux set-option -gq "$option" "$value"
 }
 
 do_interpolation() {
-  local string=$1
-  local gpu_usage_interpolated=${string/$gpu_usage_interpolation/$gpu_usage}
-  echo $gpu_usage_interpolated
+  local all_interpolated="$1"
+  for ((i = 0; i < ${#gpu_usage[@]}; i++)); do
+    all_interpolated=${all_interpolated//${gpu_interpolation[$i]}/${gpu_usage[$i]}}
+  done
+  echo "$all_interpolated"
 }
 
 update_tmux_option() {
-  local option="$1"
-  local option_value="$(get_tmux_option "$option")"
-  local new_option_value="$(do_interpolation "$option_value")"
+  local option
+  local option_value
+  local new_option_value
+  option=$1
+  option_value=$(get_tmux_option "$option")
+  new_option_value=$(do_interpolation "$option_value")
   set_tmux_option "$option" "$new_option_value"
 }
 

--- a/scripts/vram.sh
+++ b/scripts/vram.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+print_gpu_usage() {
+    function getVRAMUsage() {
+	    vramTotal=($(nvidia-smi -q -d MEMORY | grep Total | awk '{print $3}'))
+	    vramUsed=($(nvidia-smi -q -d MEMORY | grep Used | awk '{print $3}'))
+
+	    vramUsage=()
+	    for (( i=0; i<${#vramTotal[@]}; i=$((i+2)) )); do
+		    vramUsage+=( $((vramUsed[$i] * 100 / vramTotal[$i])) )
+	    done
+    }
+    getVRAMUsage
+    gpuUsage=("${vramUsage[@]/%/%}")
+    
+    function join_by { local IFS="$1"; shift; echo "$*"; }
+    gpuUsage=`join_by " " ${gpuUsage[@]}`
+    if [ -z "$gpuUsage" ]; then
+	echo "-"
+    else
+	echo "$gpuUsage"
+    fi
+}
+
+main() {
+  print_gpu_usage
+}
+
+main


### PR DESCRIPTION
`#{vram}`
Similar to the behavior of `#{gpu}`, it displays a percentage of VRAM usage (based on "FB Memory" information of `nvidia-smi`.

Screenshot:
![image](https://user-images.githubusercontent.com/5126340/163518516-1fde3826-ceca-4421-9ec5-a9a467943487.png)